### PR TITLE
Add meeetup api and change event display to pull from api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem 'jekyll', '3.1.6'
 group :jekyll_plugins do
   gem 'jekyll-feed'
   gem 'jekyll-seo-tag'
+  gem 'hash-joiner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,8 @@ GEM
   specs:
     colorator (0.1)
     ffi (1.9.18)
+    hash-joiner (0.0.7)
+      safe_yaml
     jekyll (3.1.6)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
@@ -36,9 +38,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  hash-joiner
   jekyll (= 3.1.6)
   jekyll-feed
   jekyll-seo-tag
 
 BUNDLED WITH
-   1.13.3
+   1.13.7

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,12 @@ category_dir: /
 # The URL of your actual domain. This will be used to make absolute links in the RSS feed.
 url: http://www.gdidayton.com
 
+# API to get events data from Meetup
+jekyll_get:
+  data: meetup-events
+  json: 'https://api.meetup.com/girl-develop-it-dayton/events?photo-host=public&page=20&sig_id=8881904&sig=a65da054550312ede829f4fe5ca6684c970ec407'
+  cache: false
+
 #### Under the Hood Stuff #####
 
 # Use rdiscount as the markdown engine because it generates html5 compliant code for stuff like footnotes

--- a/_includes/class_materials_list.html
+++ b/_includes/class_materials_list.html
@@ -6,7 +6,7 @@
           <img alt={{class.img.alt}} height="80" src={{class.img.src}} />
         </div>
         <div class="material-title">
-          <h2>{{class.title}}</h2>
+          <h3>{{class.title}}</h3>
           <p>{{class.subtitle}}</p>
         </div>
       </a>

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -1,13 +1,13 @@
 
-          {% for event in site.data.events %}
+          {% for event in site.data.meetup-events %}
         <article class="card">
-            <a href={{ event.link | prepend: site.baseurl }}>
-              <div class="thumb" style="background-image: url({{ event.image | prepend: site.baseurl }});"></div>
-            </a>
             <div class="infos">
-                <h3 class="title">{{ event.title }}</h3>
-                <p class="date">{{ event.date }}</p>
-                <a href={{ event.link }} class="details">details</a>
+                <h3 class="title">{{ event.name }}</h3>
+                <p class="date">{{ event.time) | divided_by: 1000 | time_zone: -5 | date: '%B %-d, %Y | %-I:%M%P'  }} </p>
+                <a href={{ event.link }} class="button">RSVP</a>
+                <div class="details">
+                <p>{{ event.description | truncatewords: 80}} <a href="{{event.link}}">[more]</a></p>
+                </div>
             </div>
         </article>
     {% endfor %}

--- a/_plugins/jekyll_get.rb
+++ b/_plugins/jekyll_get.rb
@@ -1,0 +1,40 @@
+require 'json'
+require 'hash-joiner'
+require 'open-uri'
+
+module Jekyll_Get
+  class Generator < Jekyll::Generator
+    safe true
+    priority :highest
+
+    def generate(site)
+      config = site.config['jekyll_get']
+      if !config
+        return
+      end
+      if !config.kind_of?(Array)
+        config = [config]
+      end
+      config.each do |d|
+        begin
+          target = site.data[d['data']]
+          source = JSON.load(open(d['json']))
+          if target
+            HashJoiner.deep_merge target, source
+          else
+            site.data[d['data']] = source
+          end
+          if d['cache']
+            data_source = (site.config['data_source'] || '_data')
+            path = "#{data_source}/#{d['data']}.json"
+            open(path, 'wb') do |file|
+              file << JSON.generate(site.data[d['data']])
+            end
+          end
+        rescue
+          next
+        end
+      end
+    end
+  end
+end

--- a/_scss/base/_typography.scss
+++ b/_scss/base/_typography.scss
@@ -15,12 +15,12 @@ h6 {
 }
 
 h1 {
-    font-size: 1.2rem;
+    font-size: 2rem;
     letter-spacing: .14rem;
 }
 
 h2 {
-    font-size: 1rem;
+    font-size: 1.5rem;
     letter-spacing: .14rem;
     margin: auto;
     padding: .5rem;
@@ -32,7 +32,7 @@ h2 {
 }
 
 h3 {
-    font-size: .95rem;
+    font-size: 1.2rem;
     letter-spacing: .1rem;
     margin: auto;
     padding: .1rem;

--- a/_scss/modules/_events.scss
+++ b/_scss/modules/_events.scss
@@ -5,51 +5,55 @@
 	justify-content: center;
 
 	article.card {
-		width: 80%;
+		max-width: 70%;
 		text-align:left;
 		border-radius:$border-radius;
 		margin: 15px 0;
 		box-shadow:$box-shadow;
 		overflow:hidden;
-		//
-		.thumb {
-		 	@include size(auto, 200px);
-		 	background: no-repeat center center;
-			background-size:cover;
-			border-radius:$border-radius;
-		}
 
 		.infos {
 			display: flex;
 			flex-direction: column;
-			justify-content: space-between;
-			align-items: flex-start;
+			align-items: center;
 			width: auto;
-			height: 150px;
-			padding:14px 24px;
+			padding: 14px 24px;
 			background:$white;
 
 			.title {
 				letter-spacing: 3px;
-				margin: 0;
+				margin-top: 1em;
 				color:$big-stone;
 				text-transform: uppercase;
 				text-shadow: 0 0 0px lighten($big-stone, 20);
 			}
-
+			
 			.date {
 				color:$lite-big-stone;
 				font-family: $grotesque-regular;
+				margin: 5px;
 			}
 
 			.details {
-				letter-spacing: 1px;
-				color:$smalt-blue;
-				font-family: $grotesque-black;
-				text-transform: uppercase;
-				text-decoration: none;
-				cursor:pointer;
+
+				p {
+					margin: 1em;
+					padding: 0 1em;
+					font-size: .875rem;
+					letter-spacing: .03rem;
+				}
 			}
-		}
+
+			img {
+				width: 100%;
+				margin: 0 auto;
+			}
+			
+			.button {
+				font-size: 1.3em;
+				margin-top: .5em;
+				padding: .5em;
+			}
 	}
+}
 }

--- a/_scss/states/_desktop.scss
+++ b/_scss/states/_desktop.scss
@@ -34,11 +34,11 @@
     //modules/events.scss
     .event-list {
         article.card {
-            width: 30%;
+            width: 70%;
             margin: 15px;
 
-            .thumb {
-                @include size(auto, 200px);
+            .title {
+                font-size: 1.7em;
             }
         }
     }
@@ -75,10 +75,10 @@
 
 @include breakpoint-widescreen {
     .event-list {
-        width: 60%;
+        width: 70%;
 
         article.card {
-            width: 30%;
+            width: 70%;
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -26,9 +26,8 @@ layout: default
         <section class="map">
             <div class="container">
                 <div class="underlined-headline">
-                    <h2>We are coding now in the Gem City</h2>
+                    <h2>Upcoming Events!</h2>
                     <hr>
-                    <a class=" subtitle" target="_blank" href="http://www.meetup.com/Girl-Develop-It-Dayton/">Upcoming events!</a>
                 </div>
             </div>
             <div class="container event-list">


### PR DESCRIPTION
Changes proposed:

* Add [jekyll_get plugin](https://github.com/18F/jekyll-get) to pull data from an external json source
* Add hash-joiner gem dependency for jekyll_get
* Add setup in config file to create meetup-events data (json) and pull upcoming events for gdi dayton from the meetup api
* Edit events include file to pull from the meetup-events data and display event cards to user
* Adjust styles for updated typography and event cards
* Updated class title headings on the class materials page
* Remove 'We are coding now in the Gem City' from the home page

**BEFORE:**
![screencapture-gdidayton-1500228735674](https://user-images.githubusercontent.com/2197515/28250177-d21eb4d6-6a30-11e7-8eff-12d1a01176d3.png)

**AFTER:**
![screencapture-127-0-0-1-4000-1500228766172](https://user-images.githubusercontent.com/2197515/28250181-eeb7c88a-6a30-11e7-8806-c1638a82fc70.png)


